### PR TITLE
Adding support for Azure Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ to see which methods has been overridden.
 
 ### Receiving messages in Azure Functions
 
-To receive compressed messages in Azure Functions that use the `[ServiceBusTrigger]`, register:
+To receive compressed messages in Azure Functions that use the `[ServiceBusTrigger]`, register in `Startup.cs`:
 
 ``` cs
 services.AddCompressionAwareServiceBusMessageHandler();
@@ -123,17 +123,17 @@ services.AddCompressionAwareServiceBusMessageHandler();
 Then use the `CompressionAwareServiceBusMessageHandler` to decompress the message:
 ``` cs
 public class MyFunction {
-    private CompressionAwareServiceBusMessageHandler _reciever;
+    private CompressionAwareServiceBusMessageHandler _handler;
 
-    public MyFunction(CompressionAwareServiceBusMessageHandler receiver)
+    public MyFunction(CompressionAwareServiceBusMessageHandler handler)
     {
-        _reciever = reciever;
+        _handler = handler;
     }
 
     [Function("MyFunction")]
     public async Task Run([ServiceBusTrigger("MyTopic", "MysSubscriptionName", Connection = "ServiceBus")] ServiceBusReceivedMessage message)
     {
-        message = _reciever.HandleMessageReceived(message);
+        message = _handler.HandleMessageReceived(message);
     }    
 }    
 ``` 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,32 @@ var messages = await receiver.ReceiveMessagesAsync(10, cancellationToken: cancel
 Please check the class [CompressionAwareServiceBusReceiver](https://github.com/tlogik/Azure.Messaging.ServiceBus.Compression/blob/main/src/Azure.Messaging.ServiceBus.Compression/CompressionAwareServiceBusReceiver.cs)
 to see which methods has been overridden.
 
+### Receiving messages in Azure Functions
+
+To receive compressed messages in Azure Functions that use the `[ServiceBusTrigger]`, register:
+
+``` cs
+services.AddCompressionAwareServiceBusMessageHandler();
+```
+
+Then use the `CompressionAwareServiceBusMessageHandler` to decompress the message:
+``` cs
+public class MyFunction {
+    private CompressionAwareServiceBusMessageHandler _reciever;
+
+    public MyFunction(CompressionAwareServiceBusMessageHandler receiver)
+    {
+        _reciever = reciever;
+    }
+
+    [Function("MyFunction")]
+    public async Task Run([ServiceBusTrigger("MyTopic", "MysSubscriptionName", Connection = "ServiceBus")] ServiceBusReceivedMessage message)
+    {
+        message = _reciever.HandleMessageReceived(message);
+    }    
+}    
+``` 
+
 ### Custom compressions
 
 Configuration and registration
@@ -140,6 +166,3 @@ var client = new CompressionAwareServiceBusClient(connectionString: "YOUR_SERVIC
 
 ### Overrides
 Only a subset of overrides has been implemented. The overrides should be sufficient to support the purpose of compressing and decompressing message Payloads but if you find something is missing please feel free to fix and create PR.
-
-### Azure functions
-Since Azure function [ServiceBusTrigger] attributes uses other library to instanciate its connection to the Servicebus, this lib cannot be used to change how the FunctionApp will get messages.

--- a/src/Azure.Messaging.ServiceBus.Compression/Azure.Messaging.ServiceBus.Compression.csproj
+++ b/src/Azure.Messaging.ServiceBus.Compression/Azure.Messaging.ServiceBus.Compression.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <RootNamespace>Azure.Messaging.ServiceBus.Compression</RootNamespace>
         <AssemblyName>Azure.Messaging.ServiceBus.Compression</AssemblyName>
-        <LangVersion>8</LangVersion>
+        <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
         <VersionPrefix>0.9.5</VersionPrefix>
         <PackageId>AzureServiceBus.Compression</PackageId>
@@ -19,7 +19,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
+      <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.13.1" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     </ItemGroup>
 
 </Project>

--- a/src/Azure.Messaging.ServiceBus.Compression/CompressionAwareServiceBusMessageHandler.cs
+++ b/src/Azure.Messaging.ServiceBus.Compression/CompressionAwareServiceBusMessageHandler.cs
@@ -1,0 +1,42 @@
+﻿using Azure.Messaging.ServiceBus.Compression.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Messaging.ServiceBus.Compression
+{
+    public class CompressionAwareServiceBusMessageHandler
+    {
+        private readonly CompressionConfiguration _configuration;
+
+        public CompressionAwareServiceBusMessageHandler(CompressionConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public ServiceBusReceivedMessage HandleMessageReceived(ServiceBusReceivedMessage message)
+        {
+            return !message.IsCompressed(out var compressionMethodName) ? message : DecompressAndSetBody(message, compressionMethodName);
+        }
+        private ServiceBusReceivedMessage DecompressAndSetBody(ServiceBusReceivedMessage message, string decompressorName)
+        {
+            var decompressed = message.DeCompressToByteArray(decompressorName, _configuration);
+            return Map(message, decompressed);
+        }
+
+        private ServiceBusReceivedMessage Map(ServiceBusReceivedMessage message, byte[] body)
+        {
+            if (body.Length == 0) return message;
+
+            //It is not really easy to create the body proper - however the ServiceBusMessage is able to. Thus the Hack is.
+            // Let ServiceBusMessage create the new body and pass it to the ServiceBusReceivedMessage
+            var msg = new ServiceBusMessage(body);
+            var raw = message.GetRawAmqpMessage();
+            raw.Body = msg.GetRawAmqpMessage().Body; //Is reference and thus actually changes the body on the ServiceBusReceivedMessage
+            return message;
+
+        }
+    }
+}

--- a/src/Azure.Messaging.ServiceBus.Compression/CompressionAwareServiceBusReceiver.cs
+++ b/src/Azure.Messaging.ServiceBus.Compression/CompressionAwareServiceBusReceiver.cs
@@ -55,5 +55,10 @@ namespace Azure.Messaging.ServiceBus.Compression
             var messages =  await base.PeekMessagesAsync(maxMessages, fromSequenceNumber, cancellationToken).ConfigureAwait(false);
             return messages.Select(_messageHandler.HandleMessageReceived).ToList().AsReadOnly();
         }
+
+        internal ServiceBusReceivedMessage HandleMessageReceived(ServiceBusReceivedMessage message)
+        {
+            return _messageHandler.HandleMessageReceived(message);
+        }
     }
 }

--- a/src/Azure.Messaging.ServiceBus.Compression/CompressionAwareServiceBusReceiver.cs
+++ b/src/Azure.Messaging.ServiceBus.Compression/CompressionAwareServiceBusReceiver.cs
@@ -10,7 +10,13 @@ namespace Azure.Messaging.ServiceBus.Compression
     public class CompressionAwareServiceBusReceiver : ServiceBusReceiver
     {
         private readonly CompressionConfiguration _configuration;
-        
+        private CompressionAwareServiceBusMessageHandler _messageHandler;
+
+        public CompressionAwareServiceBusReceiver()
+        {
+            _messageHandler = new CompressionAwareServiceBusMessageHandler(_configuration);
+        }
+
         public CompressionAwareServiceBusReceiver(string queueName, ServiceBusClient client,
             CompressionConfiguration configuration, ServiceBusReceiverOptions options) : base(client, queueName, options)
         {
@@ -29,7 +35,7 @@ namespace Azure.Messaging.ServiceBus.Compression
             CancellationToken cancellationToken = new CancellationToken())
         {
             var messages =  await base.ReceiveMessagesAsync(maxMessages, maxWaitTime, cancellationToken).ConfigureAwait(false);
-            return messages.Select(HandleMessageReceived).ToList().AsReadOnly();
+            return messages.Select(_messageHandler.HandleMessageReceived).ToList().AsReadOnly();
         }
 
         public override async Task<ServiceBusReceivedMessage> ReceiveMessageAsync(TimeSpan? maxWaitTime = null,
@@ -37,45 +43,20 @@ namespace Azure.Messaging.ServiceBus.Compression
         {
             var message = await base.ReceiveMessageAsync(maxWaitTime, cancellationToken).ConfigureAwait(false);
 
-            return HandleMessageReceived(message);
+            return _messageHandler.HandleMessageReceived(message);
         }
 
         public override async Task<ServiceBusReceivedMessage> PeekMessageAsync(long? fromSequenceNumber = null, CancellationToken cancellationToken = new CancellationToken())
         {
             var message = await  base.PeekMessageAsync(fromSequenceNumber, cancellationToken).ConfigureAwait(false);
-            return HandleMessageReceived(message);
+            return _messageHandler.HandleMessageReceived(message);
         }
 
         public override async Task<IReadOnlyList<ServiceBusReceivedMessage>> PeekMessagesAsync(int maxMessages, long? fromSequenceNumber = null,
             CancellationToken cancellationToken = new CancellationToken())
         {
             var messages =  await base.PeekMessagesAsync(maxMessages, fromSequenceNumber, cancellationToken).ConfigureAwait(false);
-            return messages.Select(HandleMessageReceived).ToList().AsReadOnly();
-        }
-
-
-        internal ServiceBusReceivedMessage HandleMessageReceived(ServiceBusReceivedMessage message)
-        {
-            
-            return !message.IsCompressed( out var compressionMethodName) ? message : DecompressAndSetBody(message, compressionMethodName);
-        }
-        private ServiceBusReceivedMessage DecompressAndSetBody(ServiceBusReceivedMessage message, string decompressorName)
-        {
-            var decompressed = message.DeCompressToByteArray(decompressorName, _configuration);
-            return Map(message, decompressed);
-        }
-
-        private ServiceBusReceivedMessage Map(ServiceBusReceivedMessage message, byte[] body)
-        {
-            if (body.Length == 0) return message;
-
-            //It is not really easy to create the body proper - however the ServiceBusMessage is able to. Thus the Hack is.
-            // Let ServiceBusMessage create the new body and pass it to the ServiceBusReceivedMessage
-            var msg = new ServiceBusMessage(body);
-            var raw = message.GetRawAmqpMessage();
-            raw.Body = msg.GetRawAmqpMessage().Body; //Is reference and thus actually changes the body on the ServiceBusReceivedMessage
-            return message;
-
+            return messages.Select(_messageHandler.HandleMessageReceived).ToList().AsReadOnly();
         }
     }
 }

--- a/src/Azure.Messaging.ServiceBus.Compression/CompressionAwareServiceBusReceiver.cs
+++ b/src/Azure.Messaging.ServiceBus.Compression/CompressionAwareServiceBusReceiver.cs
@@ -10,18 +10,14 @@ namespace Azure.Messaging.ServiceBus.Compression
     public class CompressionAwareServiceBusReceiver : ServiceBusReceiver
     {
         private readonly CompressionConfiguration _configuration;
-        private CompressionAwareServiceBusMessageHandler _messageHandler;
-
-        public CompressionAwareServiceBusReceiver()
-        {
-            _messageHandler = new CompressionAwareServiceBusMessageHandler(_configuration);
-        }
+        private readonly CompressionAwareServiceBusMessageHandler _messageHandler;
 
         public CompressionAwareServiceBusReceiver(string queueName, ServiceBusClient client,
             CompressionConfiguration configuration, ServiceBusReceiverOptions options) : base(client, queueName, options)
         {
             Guard.AgainstNull(nameof(configuration), configuration);
             _configuration = configuration;
+            _messageHandler = new CompressionAwareServiceBusMessageHandler(_configuration);
         }
         
         public CompressionAwareServiceBusReceiver(string topicName,string subscriptionName, ServiceBusClient client,
@@ -29,6 +25,7 @@ namespace Azure.Messaging.ServiceBus.Compression
         {
             Guard.AgainstNull(nameof(configuration), configuration);
             _configuration = configuration;
+            _messageHandler = new CompressionAwareServiceBusMessageHandler(_configuration);
         }
 
         public override async Task<IReadOnlyList<ServiceBusReceivedMessage>> ReceiveMessagesAsync(int maxMessages, TimeSpan? maxWaitTime = null,

--- a/src/Azure.Messaging.ServiceBus.Compression/Extensions/ServiceBusCompressionAwareClientBuilderExtensions.cs
+++ b/src/Azure.Messaging.ServiceBus.Compression/Extensions/ServiceBusCompressionAwareClientBuilderExtensions.cs
@@ -1,9 +1,7 @@
-using System;
-using System.ComponentModel;
 using Azure.Core.Extensions;
 using Azure.Messaging.ServiceBus;
-using Azure.Messaging.ServiceBus.Administration;
 using Azure.Messaging.ServiceBus.Compression;
+using Microsoft.Extensions.DependencyInjection;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Azure
@@ -41,6 +39,15 @@ namespace Microsoft.Extensions.Azure
             Guard.AgainstNegativeOrZero(nameof(compressionThresholdLimitBytes), compressionThresholdLimitBytes);
             return builder.RegisterClientFactory<ServiceBusClient, ServiceBusClientOptions>(options => new CompressionAwareServiceBusClient(connectionString, options, new GzipCompressionConfiguration(compressionThresholdLimitBytes)));
         }
-        
+
+        public static IServiceCollection AddCompressionAwareServiceBusMessageHandler(this IServiceCollection services, int compressionThresholdLimitBytes = GzipCompressionConfiguration.MinimumCompressionSize)
+        {
+            return services.AddSingleton(new CompressionAwareServiceBusMessageHandler(new GzipCompressionConfiguration(compressionThresholdLimitBytes)));
+        }
+
+        public static IServiceCollection AddCompressionAwareServiceBusMessageHandler(this IServiceCollection services, CompressionConfiguration configuration)
+        {
+            return services.AddSingleton(new CompressionAwareServiceBusMessageHandler(configuration));
+        }
     }
 }


### PR DESCRIPTION
To receive compressed messages in Azure Functions that use the `[ServiceBusTrigger]`, register in `Startup.cs`:

``` cs
services.AddCompressionAwareServiceBusMessageHandler();
```

Then use the `CompressionAwareServiceBusMessageHandler` to decompress the message:
``` cs
public class MyFunction {
    private CompressionAwareServiceBusMessageHandler _handler;

    public MyFunction(CompressionAwareServiceBusMessageHandler handler)
    {
        _handler = handler;
    }

    [Function("MyFunction")]
    public async Task Run([ServiceBusTrigger("MyTopic", "MysSubscriptionName", Connection = "ServiceBus")] ServiceBusReceivedMessage message)
    {
        message = _handler.HandleMessageReceived(message);
    }    
}    
``` 